### PR TITLE
feat: Support custom toggle prefix

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -90,6 +90,17 @@ module.exports = {
 
 The option `queryString` is used to enable query string support, so if the url contains a toggle query string, then the feature toggles with the matching value will be forced to show.
 
+### Change key prefix
+
+To change the default toggle prefix for `toggle`, you can now pass an option to change it to anything you like, such as:
+```
+<feature-toggle name="my-unique-key" :value="true" prefix="_t">
+  <p>This can only show if the toggle is enabled</p>
+</feature-toggle>
+```
+
+In this case, the key is now `_t_my-unique-key`
+
 ### Allowing access
 
 You can control the access of the query string using a function, this can be defined using the following approach.

--- a/lib/feature-toggle.vue
+++ b/lib/feature-toggle.vue
@@ -9,7 +9,11 @@ export default {
   name: 'feature-toggle',
   props: {
     name: String,
-    value: [String, Boolean]
+    value: [String, Boolean],
+    prefix: {
+      type: String,
+      default: 'toggle'
+    }
   },
   computed: {
     queryString() {
@@ -21,7 +25,7 @@ export default {
     },
 
     queryStringKey() {
-      return `toggle_${this.name}`
+      return `${this.prefix}_${this.name}`
     },
 
     hasQueryStringWithToggle(){

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -98,6 +98,24 @@ describe('FeatureToggle', () => {
 
       expect(actual).toBe(true)
     })
+
+    it('should return false if the query string does not match and with a custom prefix', () => {
+      const wrapper = getWrapper({
+        extraPropsData: {
+          prefix: '_t'
+        },
+        extraQuery: {
+          '_t_my-unique-toggle': 'false'
+        },
+        extraFeatureToggle: {
+          queryString: true
+        }
+      })
+
+      const actual = wrapper.vm.canShowWithQueryString
+
+      expect(actual).toBe(false)
+    })
   })
 
   describe('queryStringKey', () => {

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -80,6 +80,24 @@ describe('FeatureToggle', () => {
 
       expect(actual).toBe(true)
     })
+
+    it('should return true if the query string matches and with a custom prefix', () => {
+      const wrapper = getWrapper({
+        extraPropsData: {
+          prefix: '_t'
+        },
+        extraQuery: {
+          '_t_my-unique-toggle': 'true'
+        },
+        extraFeatureToggle: {
+          queryString: true
+        }
+      })
+
+      const actual = wrapper.vm.canShowWithQueryString
+
+      expect(actual).toBe(true)
+    })
   })
 
   describe('queryStringKey', () => {


### PR DESCRIPTION
Adds support for a custom toggle prefix.

### Example
`_t_my_toggle` is now supported and does not need to be `toggle_my_toggle`.

```js
<feature-toggle name="my_toggle" value="option-2" prefix="_t">
    <h1>With title</h1>
    <p>hello world</p>
</feature-toggle>
```