### PR TITLE
fix readme docs for runtime config

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -79,8 +79,10 @@ feature toggles on-the-fly without having to rebuild** (only need to restart Nux
 module.exports = {
   modules: ['nuxt-feature-toggle'],
   publicRuntimeConfig: {
-    toggles: {
-      somePreviewFeature: process.env.FEATURE_ENABLE_SOME_PREVIEW_FEATURE,
+    featureToggle:{
+      toggles: {
+        somePreviewFeature: process.env.FEATURE_ENABLE_SOME_PREVIEW_FEATURE,
+      }
     }
   }
 }


### PR DESCRIPTION
The docs for runtime config are wrong, they showed to just use `toggles` however you need to put that inside `featureToggle` like the rest of the options