### PR TITLE
Process querystring toggles when injecting (Implement #14)

### DIFF
--- a/examples/demo/pages/index.vue
+++ b/examples/demo/pages/index.vue
@@ -73,6 +73,11 @@
           </feature-toggle>
         </section>
       </div>
+      <br>
+      <hr >
+      <p>Serialized toggles (output of <code>$featureToggle.toggles</code>):</p>
+      <pre>{{ JSON.stringify($featureToggle.toggles, null, 2) }}</pre>
+      <hr>
     </div>
   </section>
 </template>
@@ -85,7 +90,7 @@ export default {
     },
     toggleMyUniqueKey: {
       get() {
-        return this.$route.query['toggle_my-unique-key'] || true
+        return this.$route.query['toggle_my-unique-key'] || this.$featureToggle.toggles['my-unique-key'] || true
       },
       set(newValue) {
         this.$router.push({
@@ -99,7 +104,7 @@ export default {
     },
     toggleBodySection: {
       get() {
-        return this.$route.query['toggle_body-section'] || 'option-1'
+        return this.$route.query['toggle_body-section'] || this.$featureToggle.toggles['body-section'] || 'option-1'
       },
       set(newValue) {
         this.$router.push({
@@ -160,5 +165,22 @@ export default {
 }
 .demo-panel table td:last-child {
   text-align: right;
+}
+
+hr {
+  margin: 2rem 0;
+}
+
+code {
+  display: inline-block;
+  background-color: oldlace;
+  padding: 0.15rem 0.25rem;
+  color: crimson;
+}
+
+pre {
+  background-color: oldlace;
+  margin: 1rem 0;
+  padding: 1rem;
 }
 </style>

--- a/lib/feature-toggle.vue
+++ b/lib/feature-toggle.vue
@@ -12,10 +12,14 @@ export default {
     value: [String, Boolean],
     prefix: {
       type: String,
-      default: 'toggle'
+      default: undefined
     }
   },
   computed: {
+    prefixValue () {
+      return this.prefix || this.$featureToggle.queryStringPrefix;
+    },
+
     queryString() {
       return this.$featureToggle.queryString
     },
@@ -25,7 +29,7 @@ export default {
     },
 
     queryStringKey() {
-      return `${this.prefix}_${this.name}`
+      return `${this.prefixValue}_${this.name}`
     },
 
     hasQueryStringWithToggle(){

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,8 +1,13 @@
 const { resolve } = require('path')
 const resolveToggles = require('./resolveToggles')
 
+const defaultOptions = {
+  queryStringPrefix: 'toggle'
+}
+
 async function featureToggleModule (moduleOptions) {
   const options = {
+    ...defaultOptions,
     ...this.options['feature-toggle'],
     ...this.options.featureToggle,
     ...moduleOptions,
@@ -19,7 +24,8 @@ async function featureToggleModule (moduleOptions) {
     fileName: 'feature-toggles.js',
     options: {
       toggles,
-      queryString: options.queryString
+      queryString: options.queryString,
+      queryStringPrefix: options.queryStringPrefix
     },
     ssr: true
   })
@@ -32,3 +38,4 @@ async function featureToggleModule (moduleOptions) {
 
 module.exports = featureToggleModule
 module.exports.meta = require('../package.json')
+module.exports.defaultOptions = defaultOptions

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,20 +1,30 @@
 import Vue from 'vue'
 
 export default (ctx, inject) => {
-  const { toggles: _toggles, queryString: _queryString } = JSON.parse(`<%= JSON.stringify(options) %>`)
+  const { toggles: _toggles, queryString: _queryString, queryStringPrefix } = JSON.parse(`<%= JSON.stringify(options) %>`)
   const runtimeConfig = (ctx.$config && ctx.$config.featureToggle) || {}
+  const queryString = typeof runtimeConfig.queryString !== 'undefined' ? runtimeConfig.queryString : _queryString
+  let queryToggles = {}
 
+  if (queryString && ctx.route) {
+    queryToggles = Object.entries(ctx.route.query)
+      .filter(([key]) => key.startsWith(`${queryStringPrefix}_`))
+      .reduce((toggles, [key, value]) => ({
+        ...toggles,
+        [key.replace(`${queryStringPrefix}_`, '')]: value
+      }), {})
+  }
   const toggles = {
     ..._toggles,
-    ...(runtimeConfig.toggles || {})
+    ...(runtimeConfig.toggles || {}),
+    ...queryToggles
   }
-  const queryString = typeof runtimeConfig.queryString !== 'undefined' ? runtimeConfig.queryString : _queryString
-
   Vue.component('feature-toggle', () => import('./feature-toggle.vue'))
 
   const featureToggle = {
     toggles,
     queryString,
+    queryStringPrefix,
     isQueryStringAllowed: (fn) => {
       featureToggle.isQueryStringAllowedFn = fn
     }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,18 +1,30 @@
 import Vue from 'vue'
 
+const parseQueryToggles = (queryObject = {}, queryStringPrefix = '') => Object.entries(queryObject)
+  .filter(([key]) => key.startsWith(`${queryStringPrefix}_`))
+  .reduce((toggles, [key, value]) => ({
+    ...toggles,
+    [key.replace(`${queryStringPrefix}_`, '')]: value
+  }), {})
+
 export default (ctx, inject) => {
+  const { $config, route, app: { router } } = ctx
   const { toggles: _toggles, queryString: _queryString, queryStringPrefix } = JSON.parse(`<%= JSON.stringify(options) %>`)
-  const runtimeConfig = (ctx.$config && ctx.$config.featureToggle) || {}
+  const runtimeConfig = ($config && $config.featureToggle) || {}
   const queryString = typeof runtimeConfig.queryString !== 'undefined' ? runtimeConfig.queryString : _queryString
   let queryToggles = {}
 
-  if (queryString && ctx.route) {
-    queryToggles = Object.entries(ctx.route.query)
-      .filter(([key]) => key.startsWith(`${queryStringPrefix}_`))
-      .reduce((toggles, [key, value]) => ({
-        ...toggles,
-        [key.replace(`${queryStringPrefix}_`, '')]: value
-      }), {})
+  if (queryString) {
+    if (router && route) {
+      queryToggles = parseQueryToggles(route.query, queryStringPrefix)
+      router.afterEach((to) => {
+        featureToggle.toggles = {
+          ..._toggles,
+          ...(runtimeConfig.toggles || {}),
+          ...parseQueryToggles(to.query, queryStringPrefix)
+        }
+      })
+    }
   }
   const toggles = {
     ..._toggles,

--- a/lib/resolveToggles.js
+++ b/lib/resolveToggles.js
@@ -1,4 +1,4 @@
-module.exports = async function (toggles) {
+module.exports = function (toggles) {
   if (typeof toggles === 'function') {
     try {
       return toggles()

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -1,5 +1,6 @@
 import { shallowMount } from '@vue/test-utils'
 import FeatureToggle from '../lib/feature-toggle.vue'
+import { defaultOptions } from '../lib/module'
 
 const propsData = {
   name: 'my-unique-toggle',
@@ -19,6 +20,7 @@ const getWrapper = ({ extraFeatureToggle, extraQuery, extraPropsData } = {}) =>
         }
       },
       $featureToggle: {
+        ...defaultOptions,
         ...extraFeatureToggle,
         toggles: {
           'my-unique-toggle': true
@@ -77,7 +79,6 @@ describe('FeatureToggle', () => {
       })
 
       const actual = wrapper.vm.canShowWithQueryString
-
       expect(actual).toBe(true)
     })
 
@@ -177,6 +178,20 @@ describe('FeatureToggle', () => {
       const actual = wrapper.vm.isQueryStringAllowed
 
       expect(actual).toBe(false)
+    })
+  })
+
+  describe('queryStringPrefix', () => {
+    it('should return the correct key when configuring in module options', () => {
+      const wrapper = getWrapper({
+        extraFeatureToggle: {
+          queryStringPrefix: '_t'
+        }
+      })
+
+      const actual = wrapper.vm.queryStringKey
+
+      expect(actual).toBe('_t_my-unique-toggle')
     })
   })
 })


### PR DESCRIPTION
@stephenkr thank you for putting together this module! 🥇 

After evaluating it to include it in a project I'm starting I agreed with @RyanMulready's requirement from #14 which will make this module the feature-toggle powerhouse we've been looking for!

The changes I made:
- Query string toggles are parsed now in `plugin.js` and injected into `$featureToggles` at that time, these override the toggles from all other places.
- I introduced a `queryStringPrefix` configuration option that currently defaults to `toggle` as the prop did before.
- I still left the possibility for each `<feature-toggle>` component to specify its own `prefix` to have an additional level of override if needed, if not, they'll use the default `$featureToggle.queryStringPrefix`

I adjusted the tests to comply with this behaviour, essentially passing the `defaultOptions` to the `getWrapper` utility function, additionally added tests for the new option.

The demo is also updated showing the contents of `$featureToggle.toggles`. Note how the query string reads `?toggle_my-unique-key=false&toggle_body-section=option-3` and this is updated as expected in the injected object:  
![image](https://user-images.githubusercontent.com/159962/106673168-816db700-65b1-11eb-8b92-68c94f468ccc.png)
